### PR TITLE
Moved search tab

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -43,13 +43,12 @@
             <div id="jsme_container" style="display: none; width: 380px; height: 340px; margin: auto;"></div>
             <div class="tabs">
                 <ul class="tab-list">
+                    <div class="tab active" onclick="showTab(event, 'search-tab')">Search descriptors</div>
                     <div class="tab" onclick="showTab(event, 'rdkit-chem')">RDKit Chem</div>
                     <div class="tab" onclick="showTab(event, 'rdkit-Lipinski')">RDKit Lipinski</div>
                     <div class="tab" onclick="showTab(event, 'rdkit-Crippen')">RDKit Crippen</div>
                     <div class="tab" onclick="showTab(event, 'rdkit-QED')">RDKit QED</div>
                     <div class="tab" onclick="showTab(event, 'rdkit-rdFreeSASA')">RDKit rdFreeSASA</div>
-                    <!--<div class="tab" onclick="showTab(event, 'rdkit-AllChem')">RDKit AllChem</div> -->
-                    <div class="tab active" onclick="showTab(event, 'search-tab')">Search descriptors</div>
                 </ul>
             </div>
 


### PR DESCRIPTION
Search tab is now placed first. Closes #22 

<img width="802" alt="bilde" src="https://github.com/masve123/molecule-descriptors-webtool/assets/138314732/b4acf38a-ef6b-4084-9bec-aaf404bfb29b">
